### PR TITLE
Changes to normalize behaviour in Firefox

### DIFF
--- a/backgrid-select2-cell.js
+++ b/backgrid-select2-cell.js
@@ -35,12 +35,16 @@
 
     /** @property */
     events: {
-      "close": "save",
-      "change": "save"
+      "change": "save",
+      "select2-opening": "toggleOpening",
+      "select2-open": "toggleOpen"
     },
 
     /** @property */
     select2Options: null,
+
+    /** @property */
+    opening: false,
 
     initialize: function () {
       Backgrid.SelectCellEditor.prototype.initialize.apply(this, arguments);
@@ -57,6 +61,22 @@
     },
 
     /**
+       Issues with the relatedTarget property on focusout / blur events in
+       Firefox require that we track the opening state of the select2 combo.
+     */
+    toggleOpening: function (e) {
+      this.opening = true;
+    },
+
+    /**
+       Issues with the relatedTarget property on focusout / blur events in
+       Firefox require that we track the opening state of the select2 combo.
+     */
+    toggleOpen: function (e) {
+      this.opening = false;
+    },
+
+    /**
        Renders a `select2` select box instead of the default `<select>` HTML
        element using the supplied options from #select2Options.
 
@@ -65,7 +85,15 @@
     render: function () {
       Backgrid.SelectCellEditor.prototype.render.apply(this, arguments);
       this.$el.select2(this.select2Options);
+      this.delegateEvents();
       return this;
+    },
+
+    /**
+       Returns the select2 container element
+    */
+    select2ContainerEl: function() {
+      return this.$el.parent().find("." + this.select2Options.containerCssClass);
     },
 
     /**
@@ -73,21 +101,52 @@
     */
     postRender: function () {
       var self = this;
-      this.$el.parent()
-        .find("." + this.select2Options.containerCssClass)
+
+      this.select2ContainerEl()
         .on("focusout", function (e) {
-          if (!e.relatedTarget) self.close(e);
+          // Firefox behaves differently with regards to focusout
+          // @see https://github.com/wyuenho/backgrid/issues/247
+
+          var outside = e.currentTarget !== self.select2ContainerEl()[0];
+          if (!e.relatedTarget && self.opening === false && outside) {
+            self.close(e);
+          }
         })
         .on("keydown", this.close)
         .attr("tabindex", -1).focus();
+    },
+
+    /**
+       Triggers a `backgrid:edited` event from the model so the body can close
+       this editor.
+    */
+    close: function (e) {
+      var model = this.model;
+      var column = this.column;
+      var Command = Backgrid.Command;
+      var command = new Command(e);
+      if (command.cancel()) {
+        e.stopPropagation();
+        model.trigger("backgrid:edited", model, column, new Command(e));
+      }
+      else if (command.save() || command.moveLeft() || command.moveRight() ||
+               command.moveUp() || command.moveDown() || e.type == "focusout") {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (e.type == "focusout" && this.$el.find("option").length === 1) {
+          model.set(column.get("name"), this.formatter.toRaw(this.$el.val(), model));
+        }
+        model.trigger("backgrid:edited", model, column, new Command(e));
+      }
     },
 
     remove: function () {
       this.$el.select2("destroy");
       return Backgrid.SelectCellEditor.prototype.remove.apply(this, arguments);
     }
-
   });
+
 
   /**
      Select2Cell is a cell class that renders a `select2` select box during edit


### PR DESCRIPTION
Work in progress. Already spent waaaaaaaaaaaaaaaaaaaay too much time on this :)

The crux of the issue:
1. focusout was not handled in the select editor "base class". 
2. focusout behaves differently in Firefox - relatedTarget does not work at all in FF for that event.
3. select2 has it's own internal event system that wraps around regular DOM events and it's probably safer to use those, if only they worked the same way I expected

To be continued
