### PR TITLE
Add AMD compatibility to header

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -22,6 +22,7 @@
   "globals": {
     "Backgrid": false,
     "Backbone": false,
-    "_": false
+    "_": false,
+    "define": false
   }
 }

--- a/backgrid-select2-cell.js
+++ b/backgrid-select2-cell.js
@@ -6,17 +6,21 @@
   Licensed under the MIT @license.
 */
 (function (root, factory) {
-
-  // CommonJS
-  if (typeof exports == "object") {
-    require("select2");
-    module.exports = factory(root,
-                             require("underscore"),
-                             require("backgrid"));
+  if (typeof define === "function" && define.amd) {
+    // AMD (+ global for extensions)
+    define(["underscore", "backgrid", "select2"], function (_, Backgrid) {
+      return factory(root, _, Backgrid);
+    });
   }
-  // Browser
-  else factory(root, root._, root.Backgrid);
-
+  else if (typeof exports === "object") {
+    // CommonJS
+    require("select2");
+    module.exports = factory(root, require("underscore"), require("backgrid"));
+  }
+  else {
+    // Browser
+    factory(root, root._, root.Backgrid);
+  }
 }(this, function (root, _, Backgrid)  {
 
   "use strict";


### PR DESCRIPTION
Using same UMD header from main backgrid dist.

Backgrid can be loaded easily via AMD, so it should help to load this plugin via AMD as well.